### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+fixtures/
+index.js
+.babelrc


### PR DESCRIPTION
Currently `npm install swagger2typescript` fails because `dist.js` is not published on npm. 

```
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/laco/Works/node_modules/swagger2typescript/dist.js'
```

If `.npmignore` doesn't exists, npm uses `.gitignore` instead. (so `dist.js` will be ignored. )

Please publish `dist.js`! Thanks.
